### PR TITLE
feat: add mobile camera capture for food analysis

### DIFF
--- a/frontend/src/components/CameraCapture.jsx
+++ b/frontend/src/components/CameraCapture.jsx
@@ -1,0 +1,195 @@
+import { useRef, useState, useEffect } from "react";
+import { Button, Spinner } from "react-bootstrap";
+
+function CameraCapture({ onCapture, onCancel }) {
+  const videoRef = useRef(null);
+  const canvasRef = useRef(null);
+  const [stream, setStream] = useState(null);
+  const [capturedImage, setCapturedImage] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [hasCamera, setHasCamera] = useState(false);
+
+  useEffect(() => {
+    startCamera();
+
+    return () => {
+      stopCamera();
+    };
+  }, []);
+
+  const startCamera = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: {
+          facingMode: "environment",
+          width: { ideal: 1280 },
+          height: { ideal: 720 },
+        },
+        audio: false,
+      });
+
+      setStream(mediaStream);
+      setHasCamera(true);
+
+      if (videoRef.current) {
+        videoRef.current.srcObject = mediaStream;
+      }
+    } catch (err) {
+      setError(
+        err.name === "NotAllowedError"
+          ? "Camera permission denied. Please allow camera access."
+          : "Could not access camera. Please check permissions."
+      );
+      setHasCamera(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const stopCamera = () => {
+    if (stream) {
+      stream.getTracks().forEach((track) => track.stop());
+      setStream(null);
+    }
+  };
+
+  const capturePhoto = () => {
+    if (!videoRef.current || !canvasRef.current) return;
+
+    const context = canvasRef.current.getContext("2d");
+    const video = videoRef.current;
+
+    canvasRef.current.width = video.videoWidth;
+    canvasRef.current.height = video.videoHeight;
+
+    context.drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
+
+    const imageDataUrl = canvasRef.current.toDataURL("image/jpeg", 0.95);
+    setCapturedImage(imageDataUrl);
+  };
+
+  const handleRetake = () => {
+    setCapturedImage(null);
+  };
+
+  const handleConfirmCapture = () => {
+    if (!capturedImage) return;
+
+    canvasRef.current.toBlob((blob) => {
+      const file = new File([blob], "camera_capture.jpg", {
+        type: "image/jpeg",
+      });
+
+      onCapture(file, capturedImage);
+      stopCamera();
+    }, "image/jpeg");
+  };
+
+  if (error) {
+    return (
+      <div className="rounded-4 border border-danger bg-danger bg-opacity-10 p-4 text-center">
+        <p className="text-danger mb-3">
+          <strong>Camera Error:</strong> {error}
+        </p>
+        <Button variant="outline-danger" onClick={onCancel}>
+          Back to Upload
+        </Button>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="text-center p-5">
+        <Spinner animation="border" variant="success" className="mb-3" />
+        <p className="text-muted">Accessing your camera...</p>
+      </div>
+    );
+  }
+
+  if (!hasCamera) {
+    return (
+      <div className="rounded-4 border border-warning bg-warning bg-opacity-10 p-4 text-center">
+        <p className="text-warning mb-3">
+          <strong>Camera not available</strong>
+        </p>
+        <Button variant="outline-warning" onClick={onCancel}>
+          Use File Upload Instead
+        </Button>
+      </div>
+    );
+  }
+
+  if (capturedImage) {
+    return (
+      <div className="text-center">
+        <div className="mb-4 rounded-4 overflow-hidden shadow-sm border">
+          <img
+            src={capturedImage}
+            alt="Captured food"
+            className="w-100 d-block"
+            style={{ maxHeight: "500px", objectFit: "cover" }}
+          />
+        </div>
+
+        <div className="d-flex gap-3 justify-content-center">
+          <Button variant="outline-success" onClick={handleRetake} size="lg">
+            Retake
+          </Button>
+          <Button variant="success" onClick={handleConfirmCapture} size="lg">
+            Confirm & Analyze
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="position-relative rounded-4 overflow-hidden shadow-sm border border-success border-2">
+      <video
+        ref={videoRef}
+        autoPlay
+        playsInline
+        className="w-100 d-block"
+        style={{
+          maxHeight: "500px",
+          backgroundColor: "#000",
+          objectFit: "cover",
+        }}
+      />
+
+      <canvas ref={canvasRef} className="d-none" />
+
+      <div className="position-absolute bottom-0 start-0 end-0 p-4 d-flex gap-3 justify-content-center bg-gradient">
+        <Button
+          variant="outline-light"
+          onClick={onCancel}
+          size="lg"
+          className="border-2"
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="success"
+          onClick={capturePhoto}
+          size="lg"
+          className="px-5"
+        >
+          📸 Capture
+        </Button>
+      </div>
+
+      <style>{`
+        .bg-gradient {
+          background: linear-gradient(to top, rgba(0, 0, 0, 0.8), transparent);
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export default CameraCapture;

--- a/frontend/src/pages/AiUpload.jsx
+++ b/frontend/src/pages/AiUpload.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Badge,
   Button,
@@ -18,6 +18,8 @@ import {
 } from "../services/aiApi";
 
 import { useToast } from "../context/ToastContext";
+import { isMobileDevice } from "../utils/deviceDetect";
+import CameraCapture from "../components/CameraCapture";
 
 function getTodayDate() {
   const now = new Date();
@@ -32,6 +34,8 @@ function AiUpload() {
   const { showToast } = useToast();
 
   const [analysisMode, setAnalysisMode] = useState("image");
+  const [showCamera, setShowCamera] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
 
   const [imageFile, setImageFile] = useState(null);
   const [previewUrl, setPreviewUrl] = useState("");
@@ -49,6 +53,11 @@ function AiUpload() {
 
   const [addedItemIds, setAddedItemIds] = useState([]);
   const [wholeMealAdded, setWholeMealAdded] = useState(false);
+
+  // Check if mobile on component mount
+  useEffect(() => {
+    setIsMobile(isMobileDevice());
+  }, []);
 
   function resetResultState() {
     setPrediction(null);
@@ -71,6 +80,13 @@ function AiUpload() {
 
     const url = URL.createObjectURL(file);
     setPreviewUrl(url);
+  }
+
+  function handleCameraCapture(file, previewDataUrl) {
+    setImageFile(file);
+    setPreviewUrl(previewDataUrl);
+    setShowCamera(false);
+    resetResultState();
   }
 
   async function handleAnalyzeImage(e) {
@@ -239,6 +255,21 @@ function AiUpload() {
                     Image
                   </Button>
 
+                  {isMobile && (
+                    <Button
+                      variant={
+                        analysisMode === "camera" ? "success" : "outline-success"
+                      }
+                      onClick={() => {
+                        setAnalysisMode("camera");
+                        resetResultState();
+                        setShowCamera(true);
+                      }}
+                    >
+                      📷 Camera
+                    </Button>
+                  )}
+
                   <Button
                     variant={
                       analysisMode === "text" ? "success" : "outline-success"
@@ -250,7 +281,15 @@ function AiUpload() {
                 </ButtonGroup>
               </div>
 
-              {analysisMode === "image" ? (
+              {analysisMode === "camera" && showCamera ? (
+                <CameraCapture
+                  onCapture={handleCameraCapture}
+                  onCancel={() => {
+                    setShowCamera(false);
+                    setAnalysisMode("image");
+                  }}
+                />
+              ) : analysisMode === "image" ? (
                 <Form onSubmit={handleAnalyzeImage}>
                   <Form.Group className="mb-3">
                     <Form.Label>Food Image</Form.Label>
@@ -331,7 +370,7 @@ function AiUpload() {
                 <div className="text-center mt-4">
                   <Spinner animation="border" variant="success" />
                   <p className="text-muted mt-3 mb-0">
-                    {analysisMode === "image"
+                    {analysisMode === "image" || analysisMode === "camera"
                       ? "We are analyzing your meal... Remember to drink water while waiting!"
                       : "We are estimating calories and macros... Feel free to stretch your legs while we work on it!"}
                   </p>

--- a/frontend/src/utils/deviceDetect.js
+++ b/frontend/src/utils/deviceDetect.js
@@ -1,0 +1,9 @@
+export function isMobileDevice() {
+  const userAgent = navigator.userAgent || navigator.vendor || window.opera;
+
+  // Check for common mobile user agents
+  const mobileRegex =
+    /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i;
+
+  return mobileRegex.test(userAgent.toLowerCase());
+}


### PR DESCRIPTION
Add mobile camera capture for food analysis

Users can now take photos directly from their phone camera when using the AI Food Recognition feature. The camera button appears only on mobile devices.

**Testing:**
1. Open preview link on phone
2. Navigate to "AI Food Recognition"
3. Click the 📷 Camera button
4. Allow camera access
5. Take and analyze a food photo

**Files Changed:**
- New: CameraCapture.jsx component
- New: deviceDetect.js utility
- Updated: AiUpload.jsx page